### PR TITLE
pin to ubuntu 22.04

### DIFF
--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       contents: write


### PR DESCRIPTION
ubuntu 24.04 is missing resources which is causing the build to fail. Pin to ubuntu 22.04 for now